### PR TITLE
Update messenger persona fields

### DIFF
--- a/message.go
+++ b/message.go
@@ -31,9 +31,6 @@ type Message struct {
 	// Entities for NLP
 	// https://developers.facebook.com/docs/messenger-platform/built-in-nlp/
 	NLP json.RawMessage `json:"nlp"`
-	// PersonaID is the ID of persona used when sending a message
-	// https://developers.facebook.com/docs/messenger-platform/send-messages/personas/#invoking
-	PersonaID string `json:"persona_id"`
 }
 
 // Delivery represents a the event fired when Facebook delivers a message to the

--- a/response.go
+++ b/response.go
@@ -405,6 +405,7 @@ type SendMessage struct {
 	Recipient     Recipient     `json:"recipient"`
 	Message       MessageData   `json:"message"`
 	Tag           string        `json:"tag,omitempty"`
+	PersonaID     string        `json:"persona_id,omitempty"`
 }
 
 // MessageData is a message consisting of text or an attachment, with an additional selection of optional quick replies.
@@ -488,5 +489,5 @@ type StructuredMessageButton struct {
 type SendSenderAction struct {
 	Recipient    Recipient `json:"recipient"`
 	SenderAction string    `json:"sender_action"`
-	PersonaID    string    `json:"persona_id"`
+	PersonaID    string    `json:"persona_id,omitempty"`
 }


### PR DESCRIPTION
PersonaID was added to the wrong struct with previous PR. Fixed here. Also added omitempty prop so persona wouldn't be sent if it isn't set.